### PR TITLE
Adds Tiktok Oauth client

### DIFF
--- a/lib/tiktok_oauth2_client.dart
+++ b/lib/tiktok_oauth2_client.dart
@@ -1,0 +1,92 @@
+import 'dart:convert';
+
+import 'package:dio/dio.dart';
+import 'package:http/http.dart' as http;
+import 'package:oauth2_client/access_token_response.dart';
+import 'package:oauth2_client/oauth2_client.dart';
+
+class TikTokOAuth2Client extends OAuth2Client {
+  TikTokOAuth2Client({required super.redirectUri, required super.customUriScheme})
+      : super(
+          authorizeUrl: 'https://www.tiktok.com/v2/auth/authorize',
+          tokenUrl: 'https://open.tiktokapis.com/v2/oauth/token/',
+          revokeUrl: 'https://open.tiktokapis.com/v2/oauth/revoke/',
+          scopeSeparator: ',',
+          credentialsLocation: CredentialsLocation.body,
+          clientIdKey: 'client_key',
+        );
+
+  @override
+  Future<AccessTokenResponse> requestAccessToken({
+    required String code,
+    required String clientId,
+    String? clientSecret,
+    String? codeVerifier,
+    List<String>? scopes,
+    Map<String, dynamic>? customParams,
+    Map<String, String>? customHeaders,
+    httpClient,
+  }) async {
+    final params = getTokenUrlParams(
+      code: code,
+      redirectUri: redirectUri,
+      codeVerifier: codeVerifier,
+      customParams: customParams,
+    );
+
+    final headers = {
+      ...?customHeaders,
+      ...{'Content-Type': 'application/x-www-form-urlencoded'}
+    };
+
+    var response = await _performAuthorizedRequest(
+      url: tokenUrl,
+      clientId: clientId,
+      clientSecret: clientSecret,
+      params: params,
+      headers: headers,
+      httpClient: httpClient,
+    );
+
+    return http2TokenResponse(response, requestedScopes: scopes);
+  }
+
+  Future<http.Response> _performAuthorizedRequest({
+    required String url,
+    required String clientId,
+    String? clientSecret,
+    Map? params,
+    Map<String, String>? headers,
+    http.Client? httpClient,
+  }) async {
+    final dio = Dio();
+
+    headers ??= {};
+    params ??= {};
+
+    //If a client secret has been specified, it will be sent in the "Authorization" header instead of a body parameter...
+    if (clientSecret == null) {
+      if (clientId.isNotEmpty) {
+        params[clientIdKey] = clientId;
+      }
+    } else {
+      switch (credentialsLocation) {
+        case CredentialsLocation.header:
+          headers.addAll(getAuthorizationHeader(
+            clientId: clientId,
+            clientSecret: clientSecret,
+          ));
+          break;
+        case CredentialsLocation.body:
+          params[clientIdKey] = clientId;
+          params[clientSecretKey] = clientSecret;
+          break;
+      }
+    }
+
+    var response = await dio.post<Map<String, dynamic>>(url,
+        data: params, options: Options(headers: headers, responseType: ResponseType.json));
+
+    return http.Response(jsonEncode(response.data), response.statusCode ?? 0);
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,6 +25,7 @@ dependencies:
   meta: ^1.12.0
   random_string: ^2.3.1
   web: ^1.1.0
+  dio: ^5.8.0+1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Utilizing the Dio package to generate an access token request is essential, as attempting to make the request using the https package with the header {'Content-Type': 'application/x-www-form-urlencoded'}, which is requisite for TikTok, results in the following error:
{
"error": "invalid_request",
"error_description": "The request parameters are malformed.",
"log_id": "202206221854370101130062072500FFA2"
}